### PR TITLE
format labels for long names

### DIFF
--- a/label_generation.R
+++ b/label_generation.R
@@ -19,43 +19,41 @@ email_subject <- paste(Sys.getenv("EMAIL_SUBJECT"), Sys.time())
 
 # TODO: change redcap_uri and api token for production project
 test_tube_label <- redcap_read_oneshot(redcap_uri = 'https://redcap.ctsi.ufl.edu/redcap/api/',
-                                       token = Sys.getenv("API_TOKEN"))$data %>%   
-  slice(rep(1:n(), each = 4)) %>% 
+                                       token = Sys.getenv("API_TOKEN"))$data %>%
+  slice(rep(1:n(), each = 4)) %>%
   # test code starts
-  slice(1:80) %>% 
+  slice(1:80) %>%
   mutate(
          subject_id = paste(frcovid_fn, frcovid_ln, frcovid_dob),
-         site = c(rep("KED", 40), rep("SHED", 30), rep("AED", 10))) %>% 
+         site = c(rep("KED", 40), rep("SHED", 20), rep("AED", 20))) %>%
   # test code ends
-  arrange(site, frcovid_ln)  
+  arrange(site, frcovid_ln)
 
 # create folder to store output
 output_dir <- paste0("fr_covid19_", Sys.Date())
 dir.create(output_dir, recursive = T)
 
 # create per site roster
-test_tube_label %>% 
-  split(.$site) %>% 
+test_tube_label %>%
+  split(.$site) %>%
   walk2(paste0(output_dir, "/", names(.), ".csv"), write.csv, row.names = F)
 
 # create per site barcode pdfs
-test_tube_label %>% 
-  select(sample_id, site, subject_id) %>% 
-  split(.$site) %>% 
+test_tube_label %>%
+  select(sample_id, site, subject_id) %>%
+  split(.$site) %>%
   map(~ custom_create_PDF(Labels = .$sample_id,
                           alt_text = .$subject_id,
                           type = "linear",
                           denote = c("(",")"),
-                          Fsz = 4.5,
-                          label_height = .30,
-                          label_width = 1.8,
-                          name = paste0(output_dir, "/", .$site, 
-                                         '_fr_covid_test_tube_labels_', 
+                          label_height = .20,
+                          name = paste0(output_dir, "/", .$site,
+                                         '_fr_covid_test_tube_labels_',
                                          Sys.Date())))
-                  
+
 # create FreezerPro dataset
-freezer_pro <- test_tube_label %>% 
-  select(Name = subject_id) %>%  
+freezer_pro <- test_tube_label %>%
+  select(Name = subject_id) %>%
   add_column("Sample Type" = "",
              "Freezer" = "",  "Box" = "")
 write.csv(freezer_pro, paste0(output_dir, "/FreezerPro_",Sys.Date(), ".csv"),
@@ -77,5 +75,5 @@ body_with_attachment <- list(body, attachment_object)
 
 # send the email with the attached output file
 sendmail(from = email_from, to = email_to, cc = email_cc,
-         subject = email_subject, body_with_attachment, 
+         subject = email_subject, body_with_attachment,
          control = email_server)


### PR DESCRIPTION
I made two small changes in lines 28 & 49 (adjust label settings for longer names) which is visible when printing the labels. There's some white space differences in the code. I delete my local repo and checked out fresh from master but it still existed. I'm gonna go ahead and merge as there's nothing for you to actually review.
@pbchase 